### PR TITLE
Add Photo gallery pagination to Photo News

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,7 @@ app.use(librouter.expose());
 app.page('home', '/');
 app.page('news', '/news');
 app.page('photos');
+app.page('photo', '/photos/:id');
 app.page('search', '/search');
 app.page('about', '/about');
 

--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -1,9 +1,3 @@
-/*
- * Copyright (c) 2013, Yahoo! Inc.  All rights reserved.
- * Copyrights licensed under the New BSD License.
- * See the accompanying LICENSE.txt file for terms.
- */
-
 /*jslint nomen:true*/
 /*jshint esnext:true*/
 
@@ -14,23 +8,7 @@ import {Promise} from 'promise';
 
 'use strict';
 
-function PhotoController() {
-    PhotoController.superclass.constructor.apply(this, arguments);
-};
-
-PhotoController.ATTRS = {
-    modelClass: {
-        value: PhotosModel
-    },
-    model: {
-        value: null
-    },
-    name: {
-        value: 'search'
-    }
-};
-
-extend(PhotoController, Base, {
+var PhotoController = Base.create("photo-controller", Base, [], {
     initializer: function (config) {
         var modelClass  = this.get('modelClass'),
             name        = this.get('name'),
@@ -69,7 +47,6 @@ extend(PhotoController, Base, {
                 next: +id + 1 
             });
 
-            console.log(mergedPhoto);
             return mergedPhoto;
         }
 
@@ -78,6 +55,18 @@ extend(PhotoController, Base, {
 
     then: function (fulfill, reject) {
         return this._promise.then(fulfill, reject);
+    }
+}, {
+    ATTRS: {
+        modelClass: {
+            value: PhotosModel
+        },
+        model: {
+            value: null
+        },
+        name: {
+            value: 'search'
+        }
     }
 });
 

--- a/controllers/photo.js
+++ b/controllers/photo.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE.txt file for terms.
+ */
+
+/*jslint nomen:true*/
+/*jshint esnext:true*/
+
+import PhotosModel from 'models/photos';
+import {extend, merge} from 'oop';
+import {Base} from 'base-build';
+import {Promise} from 'promise';
+
+'use strict';
+
+function PhotoController() {
+    PhotoController.superclass.constructor.apply(this, arguments);
+};
+
+PhotoController.ATTRS = {
+    modelClass: {
+        value: PhotosModel
+    },
+    model: {
+        value: null
+    },
+    name: {
+        value: 'search'
+    }
+};
+
+extend(PhotoController, Base, {
+    initializer: function (config) {
+        var modelClass  = this.get('modelClass'),
+            name        = this.get('name'),
+            model       = new modelClass(),
+            photoId     = config.id,
+            self        = this;
+
+        this.set('model', model);
+
+        this._promise = new Promise(function (fulfill, reject) {
+            if (model.isNew ? !model.isNew() : (model.size() > 0)) {
+                fulfill(self.mergeData(model, photoId));
+            }
+
+            model.load({name: name}, function (err) {
+                if (err) {
+                    console.error('** ERROR **: photo-controller.initializer() failed: %s', err);
+                    reject(err);
+                    return;
+                }
+
+                fulfill(self.mergeData(model, photoId));
+            });
+        });
+    },
+
+    mergeData: function (model, id) {
+        var photo,
+            mergedPhoto;
+
+        photo = model.item(id);
+
+        if (photo) {
+            mergedPhoto = merge(photo.toJSON(), {
+                prev: +id - 1,
+                next: +id + 1 
+            });
+
+            console.log(mergedPhoto);
+            return mergedPhoto;
+        }
+
+        return null;
+    },
+
+    then: function (fulfill, reject) {
+        return this._promise.then(fulfill, reject);
+    }
+});
+
+export default PhotoController;
+

--- a/controllers/search.js
+++ b/controllers/search.js
@@ -14,23 +14,7 @@ import {Promise} from 'promise';
 
 'use strict';
 
-function SearchController() {
-    SearchController.superclass.constructor.apply(this, arguments);
-};
-
-SearchController.ATTRS = {
-    modelClass: {
-        value: PhotosModel
-    },
-    model: {
-        value: null
-    },
-    name: {
-        value: 'search'
-    }
-};
-
-extend(SearchController, Base, {
+var SearchController = Base.create('search-controller', Base, [], {
     initializer: function (config) {
         var modelClass  = this.get('modelClass'),
             name        = this.get('name'),
@@ -58,6 +42,18 @@ extend(SearchController, Base, {
 
     then: function (fulfill, reject) {
         return this._promise.then(fulfill, reject);
+    }
+}, {
+    ATTRS: {
+        modelClass: {
+            value: PhotosModel
+        },
+        model: {
+            value: null
+        },
+        name: {
+            value: 'search'
+        }
     }
 });
 

--- a/models/photos.js
+++ b/models/photos.js
@@ -34,6 +34,7 @@ var PhotosModelList = Base.create('photos-model', ModelList, [], {
             // Attach the result.
             photos.push({
                 id: photo.id,
+                index: i,
                 title: photo.title,
                 url: photo.url,
                 user: photo.ownername

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -55,6 +55,41 @@ h1,h2,h3,h4,h5,h6 {
     background-color: rgb(244, 237, 247);
 }
 
+.photo-view {
+    background-color: rgb(28, 28, 37);
+}
+
+.photo-container {
+    margin: 0 auto;
+    margin-top: 50px;
+    display: inline-block;
+    height: 700px;
+}
+
+.left-arrow {
+    width: 0; 
+    height: 0;
+    display: block;
+    margin-left: 80px;
+    margin-top: 180px; 
+    border-top: 40px solid transparent;
+    border-bottom: 40px solid transparent; 
+    border-right: 40px solid rgb(244, 237, 247); 
+    float: left;
+}
+
+.right-arrow {
+    width: 0; 
+    height: 0;
+    display: block;
+    margin-right: 80px;
+    margin-top: 180px; 
+    border-top: 40px solid transparent;
+    border-bottom: 40px solid transparent; 
+    border-left: 40px solid rgb(244, 237, 247); 
+    float: right;
+}
+
 .content {
     background-color: white;
     padding-left: 60px;

--- a/templates/photo.handlebars
+++ b/templates/photo.handlebars
@@ -1,0 +1,11 @@
+<div class="pure-g-r">
+  <a data-page="{{ prev }}" href="/photos/{{ prev }}" class="left-arrow">
+  </a>
+  <div class="photo-container">
+    <div class="photo-image">
+      <img src="{{ url }}" />
+    </div>
+  </div>
+  <a data-page="{{ next }}" href="/photos/{{ next }}" class="right-arrow">
+  </a>
+</div>

--- a/templates/photos.handlebars
+++ b/templates/photos.handlebars
@@ -9,7 +9,7 @@
 	</div>
 	{{#each items}}
 		<div class="pure-u-1-3 photo-box">
-		    <a href="{{ url }}">
+		    <a href="/photos/{{ index }}">
 		        <img src="{{ url }}"
 		             alt="{{ title }}">
 		    </a>

--- a/views/main.js
+++ b/views/main.js
@@ -3,6 +3,7 @@
 
 // classes
 import ControllerNews from 'controllers/news';
+import ControllerPhoto from 'controllers/photo';
 import ControllerPhotos from 'controllers/photos';
 import ControllerSearch from 'controllers/search';
 
@@ -14,12 +15,14 @@ import ModelPhoto from 'models/photo';
 import ViewAbout from 'views/about';
 import ViewHome from 'views/home';
 import ViewPhotos from 'views/photos';
+import ViewPhoto from 'views/photo';
 import ViewNews from 'views/news';
 import ViewSearch from 'views/search';
 
 import {Controllers, Views, Models} from 'pn';
 
 Controllers.register('news', ControllerNews);
+Controllers.register('photo', ControllerPhoto);
 Controllers.register('photos', ControllerPhotos);
 Controllers.register('search', ControllerSearch);
 
@@ -32,6 +35,7 @@ Views.register('about',  ViewAbout);
 Views.register('home',   ViewHome);
 Views.register('news',   ViewNews);
 Views.register('photos', ViewPhotos);
+Views.register('photo',  ViewPhoto);
 Views.register('search', ViewSearch);
 
 import {BaseApp} from 'base-app';
@@ -60,6 +64,10 @@ var MainView = Base.create('main-view', BaseApp, [], {
             type: ViewPhotos,
             preserve: true
         },
+        photo: {
+            type: ViewPhoto,
+            preserve: true
+        },
         about: {
             type: ViewAbout,
             preserve: true
@@ -85,8 +93,7 @@ var MainView = Base.create('main-view', BaseApp, [], {
 
         // Set up any other necessary
 
-        this.on('photosView:next', this.nextPhotos);
-        this.on('photosView:prev', this.prevPhotos);
+        this.on('photo:navigate', this.navigatePhotos);
     },
 
     render: function (options) {
@@ -123,18 +130,9 @@ var MainView = Base.create('main-view', BaseApp, [], {
         }
     },
 
-    nextPhotos: function () {
-        var model;
-        model = this.get('model');
-        model.load();
-    },
-
-    prevPhotos: function () {
-        var model;
-        model = this.get('model');
-        model.load();
+    navigatePhotos: function (e) {
+        this.navigate('/photos/' + e.page);
     }
-
 }, {
 
     ATTRS: {}

--- a/views/main.js
+++ b/views/main.js
@@ -131,7 +131,7 @@ var MainView = Base.create('main-view', BaseApp, [], {
     },
 
     navigatePhotos: function (e) {
-        this.navigate('/photos/' + e.page);
+        this.navigate('/photos/' + e.photoId);
     }
 }, {
 

--- a/views/photo.js
+++ b/views/photo.js
@@ -1,0 +1,65 @@
+/*jslint nomen:true, node:true*/
+/*jshint esnext:true*/
+
+import {BaseView} from 'base-view';
+import {Template} from 'photonews-template-photo';
+import {Base} from 'base-build';
+
+var PhotoView = Base.create('photo-view', BaseView, [], {
+
+    photoTemplate: Template.get('photonews/photo'),
+
+    events: {
+        '.left-arrow': {
+            click: 'prev'
+        },
+        '.right-arrow': {
+            click: 'next'
+        }
+    },
+
+    initializer: function (config) {        
+        this.config = config;
+    },
+
+    render: function () {
+        var container = this.get('container'),
+            locals = this.get('locals'),
+            html;
+
+        html = this.photoTemplate({
+            prev : locals.prev,
+            next : locals.next, 
+            url  : locals.url
+        });
+
+        container.setHTML(html);
+        return this;
+    },
+
+    // for pagination
+    prev: function (e) {
+        var container = this.get('container'),
+            prevPage  = container.one('.left-arrow').getData('page');
+
+        e.preventDefault();
+
+        this.fire('photo:navigate', {
+            page: prevPage
+        });
+    },
+
+    next: function (e) {
+        var container = this.get('container'),
+            nextPage  = container.one('.right-arrow').getData('page');
+
+        e.preventDefault();
+
+        this.fire('photo:navigate', {
+            page: nextPage
+        });
+    }
+
+});
+
+export default PhotoView;

--- a/views/photo.js
+++ b/views/photo.js
@@ -40,23 +40,23 @@ var PhotoView = Base.create('photo-view', BaseView, [], {
     // for pagination
     prev: function (e) {
         var container = this.get('container'),
-            prevPage  = container.one('.left-arrow').getData('page');
+            prevId    = container.one('.left-arrow').getData('page');
 
         e.preventDefault();
 
         this.fire('photo:navigate', {
-            page: prevPage
+            photoId: prevId
         });
     },
 
     next: function (e) {
         var container = this.get('container'),
-            nextPage  = container.one('.right-arrow').getData('page');
+            nextId    = container.one('.right-arrow').getData('page');
 
         e.preventDefault();
 
         this.fire('photo:navigate', {
-            page: nextPage
+            photoId: nextId
         });
     }
 


### PR DESCRIPTION
This is a branch off of `caridy/photo-search`.

It adds a Photo view for a single image (like Flickr's image viewer) and lets you paginate between different photos, by clicking on left or right arrows.

There's currently an issue with this view that was discussed with @imalberto, which is also an issue with the search functionality.

Going from `/photos/1/` to `/photos/2/` does not trigger a page re-render, because the application is unable to determine that the view has changed.  Inside of the micro-library, the views are considered to be the same due to how `app.page` creates them.  They are not re-rendered because the micro-library can't differentiate between whether a page has been newly loaded and bootstrapped, or whether the model has changed and the view needs to be re-rendered.

The same situation currently occurs with `/search?q=miami` to `/search?q=sunnyvale`.  

This is something that we should probably discuss before moving on to our next application - it's something that's definitely going to come up again.
